### PR TITLE
Fix the density calculation.

### DIFF
--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -41,11 +41,12 @@ public class RCTImageCapInsetView extends ImageView {
         RCTImageLoaderTask task = new RCTImageLoaderTask(mUri, getContext(), new RCTImageLoaderListener() {
             @Override
             public void onImageLoaded(Bitmap bitmap) {
-                int ratio = Math.round(bitmap.getDensity() / 160);
-                int top = mCapInsets.top * ratio;
-                int right = bitmap.getWidth() - (mCapInsets.right * ratio);
-                int bottom = bitmap.getHeight() - (mCapInsets.bottom * ratio);
-                int left = mCapInsets.left * ratio;
+                float density = getContext().getResources().getDisplayMetrics().density;
+                
+                int top = Math.round(mCapInsets.top * density);
+                int right = Math.round(bitmap.getWidth() - mCapInsets.right * density);
+                int bottom = Math.round(bitmap.getHeight() - mCapInsets.bottom * density);
+                int left = Math.round(mCapInsets.left * density);
 
                 NinePatchDrawable ninePatchDrawable = NinePatchBitmapFactory.createNinePathWithCapInsets(getResources(), bitmap, top, left, bottom, right, null);
                 setBackground(ninePatchDrawable);


### PR DESCRIPTION
Summary:
The previous calculation rounded the `ratio` / `density` immediately, which affected calculations. (1.5x devices were treated as 2x.)

I don't quite understand why the calculation used the bitmap density instead of the device density, but I think this is a more reliable calculation (since it doesn't depend what assets are used).